### PR TITLE
3.0 Updates

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -13,5 +13,10 @@
   },
   "resources": {
     "media": []
-  }
+  },
+  "targetPlatforms": [
+    "aplite",
+    "basalt"
+  ],
+  "sdkVersion": "3"
 }

--- a/src/gpath-bezier.c
+++ b/src/gpath-bezier.c
@@ -6,6 +6,10 @@
 #define BENCHMARK false
 #define MAX_DEMO_PATHS 4
 
+#ifndef PBL_PLATFORM_BASALT
+#define GColorEq(c1,c2) ((c1)==(c2))
+#endif
+
 static const int rot_step = TRIG_MAX_ANGLE / 360 * 5;
 static Window *window;
 static Layer *layer;
@@ -57,11 +61,7 @@ static void select_click_handler(ClickRecognizerRef recognizer, void *context) {
 
 static void down_click_handler(ClickRecognizerRef recognizer, void *context) {
   //text_layer_set_text(text_layer, "Down");
-#ifdef PBL_COLOR
   if (GColorEq(background_color, GColorBlack)) {
-#else
-  if (background_color == GColorBlack) {
-#endif
     background_color = GColorWhite;
     foreground_color = GColorBlack;
   } else {

--- a/src/gpath-bezier.c
+++ b/src/gpath-bezier.c
@@ -12,8 +12,13 @@ static Layer *layer;
 static GPath *s_path;
 static uint8_t path_switcher = 0;
 static bool draw_line_switcher = false;
+#ifdef PBL_COLOR
+static GColor8 foreground_color;
+static GColor8 background_color;
+#else
 static GColor foreground_color;
 static GColor background_color;
+#endif
 
 static void prv_create_path(void);
 
@@ -52,7 +57,11 @@ static void select_click_handler(ClickRecognizerRef recognizer, void *context) {
 
 static void down_click_handler(ClickRecognizerRef recognizer, void *context) {
   //text_layer_set_text(text_layer, "Down");
+#ifdef PBL_COLOR
+  if (GColorEq(background_color, GColorBlack)) {
+#else
   if (background_color == GColorBlack) {
+#endif
     background_color = GColorWhite;
     foreground_color = GColorBlack;
   } else {

--- a/wscript
+++ b/wscript
@@ -5,6 +5,8 @@
 # Feel free to customize this to your needs.
 #
 
+import os.path
+
 top = '.'
 out = 'build'
 
@@ -17,8 +19,21 @@ def configure(ctx):
 def build(ctx):
     ctx.load('pebble_sdk')
 
-    ctx.pbl_program(source=ctx.path.ant_glob('src/**/*.c'),
-                    target='pebble-app.elf')
+    build_worker = os.path.exists('worker_src')
+    binaries = []
 
-    ctx.pbl_bundle(elf='pebble-app.elf',
-                   js=ctx.path.ant_glob('src/js/**/*.js'))
+    for p in ctx.env.TARGET_PLATFORMS:
+        ctx.set_env(ctx.all_envs[p])
+        app_elf='{}/pebble-app.elf'.format(ctx.env.BUILD_DIR)
+        ctx.pbl_program(source=ctx.path.ant_glob('src/**/*.c'),
+        target=app_elf)
+
+        if build_worker:
+            worker_elf='{}/pebble-worker.elf'.format(ctx.env.BUILD_DIR)
+            binaries.append({'platform': p, 'app_elf': app_elf, 'worker_elf': worker_elf})
+            ctx.pbl_worker(source=ctx.path.ant_glob('worker_src/**/*.c'),
+            target=worker_elf)
+        else:
+            binaries.append({'platform': p, 'app_elf': app_elf})
+
+    ctx.pbl_bundle(binaries=binaries, js=ctx.path.ant_glob('src/js/**/*.js'))


### PR DESCRIPTION
Updates to compile under 3.0dp1, because many hands make light work.

Just ran convert-project and put in some ifdefs, since Basalt uses GColor8's

Use Abuse or Refuse as you will, I claim no rights to any of these trivial changes.